### PR TITLE
Implementação do Unbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ If the component tag is self closing, content and children will be ignored;
 ```javascript
 	var someJson = {};
 	JSON2HTML.build(someJson);
+	var someHtml = '<div></div>';
+	JSON2HTML.unbuild(someHtml);
 ```
 
 You can check the example in docs folder.

--- a/docs/example.js
+++ b/docs/example.js
@@ -30,21 +30,11 @@ const example = {
               },
               "children": [
                 {
-                  "tag": "div",
+                  "tag": "pre",
                   "attributes": {
-                    "id": "menu1",
+                    "id": "unbuild",
                     "class": "tab-pane container active"
-                  },
-                  "children": [
-                    {
-                      "tag": "h2",
-                      "content": "Menu 1"
-                    },
-                    {
-                      "tag": "p",
-                      "content": "Boy numinous dome city Legba sprawl woman uplink voodoo god. 3D-printed grenade decay dolphin plastic math-numinous into ablative systemic rebar chrome vinyl cyber. Artisanal disposable footage warehouse saturation point otaku semiotics claymore mine futurity katana modem. Office fetishism disposable advert savant physical chrome."
-                    }
-                  ]
+                  }
                 },
                 {
                   "tag": "div",
@@ -100,14 +90,14 @@ const example = {
                     {
                       "tag": "a",
                       "attributes": {
-                        "href": "#menu1",
+                        "href": "#unbuild",
                         "class": "active",
                         "data-toggle": "tab",
                         "role": "tab",
                         "aria-controls": "home",
                         "aria-selected": "true"
                       },
-                      "content": "Menu 1"
+                      "content": "Unbuild"
                     }
                   ]
                 },

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,6 @@
 	<div id="app">
 		
 	</div>
-
 	<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
 	<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
@@ -18,7 +17,9 @@
 	<script type="text/javascript" src="example.js"></script>
 	<script type="text/javascript" src="../src/json2html.js"></script>
 	<script>
-		$('#app').html(JSON2HTML.build(example));
+		var html = JSON2HTML.build(example);
+		$('#app').html(html);
+		$('#unbuild').html(JSON.stringify(JSON2HTML.unbuild(html), null, 2));
 	</script>
 </body>
 </html>

--- a/src/json2html.js
+++ b/src/json2html.js
@@ -22,9 +22,9 @@ class JSON2HTML {
     if (!html) return {};
     const el = document.createElement('html');
     el.innerHTML = html;
-    const body = el.getElementsByTagName('body')[0];
+    const body = el.querySelector('body');
     if (!body) return {};
-    const first = body.children[0];
+    const [first] = body.children;
     if (!first) return {};
     return JSON2HTMLUnbuilder.node2json(first);
   }
@@ -88,7 +88,7 @@ class JSON2HTMLUnbuilder {
 
   static children(nodeEl) {
     const children = [];
-    for (const index in [].slice.call(nodeEl.children)) {
+    for (const index in [...nodeEl.children]) {
       if ({}.hasOwnProperty.call(nodeEl.children, index)) {
         children.push(JSON2HTMLUnbuilder.node2json(nodeEl.children[index]));
       }

--- a/src/json2html.js
+++ b/src/json2html.js
@@ -7,6 +7,30 @@ class JSON2HTML {
     ];
   }
 
+  static build(json) {
+    if (!json) return '';
+    const atributes = JSON2HTMLBuilder.attributtes(json);
+    if (JSON2HTMLBuilder.isSelfCloseTag(json)) {
+      return `<${json.tag} ${atributes}/>`;
+    }
+    const children = JSON2HTMLBuilder.children(json);
+    const content = JSON2HTMLBuilder.content(json);
+    return `<${json.tag} ${atributes}>${children} ${content}</${json.tag}>`;
+  }
+
+  static unbuild(html) {
+    if (!html) return {};
+    const el = document.createElement('html');
+    el.innerHTML = html;
+    const body = el.getElementsByTagName('body')[0];
+    if (!body) return {};
+    const first = body.children[0];
+    if (!first) return {};
+    return JSON2HTMLUnbuilder.node2json(first);
+  }
+}
+
+class JSON2HTMLBuilder {
   static attributtes(json) {
     if (!json.attributes) return '';
     let html = '';
@@ -34,18 +58,49 @@ class JSON2HTML {
     return json && json.content || '';
   }
 
-  static build(json) {
-    if (!json) return '';
-    const atributes = JSON2HTML.attributtes(json);
-    if (JSON2HTML.isSelfCloseTag(json)) {
-      return `<${json.tag} ${atributes}/>`;
-    }
-    const children = JSON2HTML.children(json);
-    const content = JSON2HTML.content(json);
-    return `<${json.tag} ${atributes}>${children} ${content}</${json.tag}>`;
-  }
-
   static isSelfCloseTag(json) {
     return (JSON2HTML.selfCloseTags.indexOf(json.tag)>-1);
+  }
+};
+
+
+class JSON2HTMLUnbuilder {
+  static attributes(nodeEl) {
+    const attributes = {};
+    const keys = Object.keys(nodeEl.attributes);
+    for (const index in keys) {
+      if ({}.hasOwnProperty.call(keys, index)) {
+        const key = keys[index];
+        const attribute = nodeEl.attributes[key];
+        attributes[attribute.name] = attribute.value;
+      }
+    }
+    return attributes;
+  }
+
+  static content(nodeEl) {
+    const cloned = nodeEl.cloneNode();
+    while (cloned.firstChild) {
+      cloned.removeChild(cloned.firstChild);
+    }
+    return cloned.innerText;
+  }
+
+  static children(nodeEl) {
+    const children = [];
+    for (const index in [].slice.call(nodeEl.children)) {
+      if ({}.hasOwnProperty.call(nodeEl.children, index)) {
+        children.push(JSON2HTMLUnbuilder.node2json(nodeEl.children[index]));
+      }
+    }
+    return children;
+  }
+  static node2json(nodeEl) {
+    return {
+      tag: nodeEl.tagName.toLowerCase(),
+      attributes: JSON2HTMLUnbuilder.attributes(nodeEl),
+      content: JSON2HTMLUnbuilder.content(nodeEl),
+      children: JSON2HTMLUnbuilder.children(nodeEl),
+    };
   }
 };


### PR DESCRIPTION
Surgiu a necessidade de fazer a operação nas duas vias:
- Converter o `JSON` para `HTML`; Chamado hoje de build.
- Converter o `HTML` para `JSON`;

Ate este ponto tinhamos apenas:
JSON2HTML com a função `builder`;
com seus respectivos métodos para processamento de `children`, `attributes`, `content`.

Como foi necessária a implementação desses métodos também para o unbuild.` JSON2HTML` foi separado em `JSON2HTMLBuilder` e `JSON2HTMLUnbuilder` para estas 3 operações e` JSON2HTML` aloca apenas os métodos de `build` e `unbuild`.